### PR TITLE
Copyright reference update: 2023 -> 2024

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -41,7 +41,7 @@
                     </div>
                 </li>
                 <li>
-                    Copyright &copy; Skillbill 2023
+                    Copyright &copy; Skillbill 2024
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
Global copyright year update.
![Screenshot from 2024-04-15 16-35-00](https://github.com/Skillbill/company-site/assets/103034224/26b6ae7a-1750-4670-8f64-4a10f30ea102)
